### PR TITLE
Fix when some buildManifest parts are undefined

### DIFF
--- a/clean-assets-plugin.js
+++ b/clean-assets-plugin.js
@@ -45,10 +45,10 @@ class CleanAssetsPlugin {
         // Gather chunk files from the build manifest, removing duplicates
         let chunkFiles = [
           ...new Set([
-            ...buildManifest.pages['/_polyfills'],
-            ...buildManifest.pages[pageKey],
-            ...buildManifest.pages['/_app'],
-            ...buildManifest.lowPriorityFiles
+            ...buildManifest.pages['/_polyfills'] || [],
+            ...buildManifest.pages[pageKey] || [],
+            ...buildManifest.pages['/_app'] || [],
+            ...buildManifest.lowPriorityFiles || []
           ])
         ];
 


### PR DESCRIPTION
The plugin failed when buildManifest.pages['/.polyfill'] is undefined.